### PR TITLE
Add missing includes.

### DIFF
--- a/include/pumex/AssetBufferNode.h
+++ b/include/pumex/AssetBufferNode.h
@@ -21,6 +21,7 @@
 //
 
 #pragma once
+#include <functional>
 #include <pumex/AssetBuffer.h>
 #include <pumex/Export.h>
 #include <pumex/Node.h>

--- a/include/pumex/Viewer.h
+++ b/include/pumex/Viewer.h
@@ -33,6 +33,7 @@
 #include <tbb/flow_graph.h>
 #include <pumex/Export.h>
 #include <pumex/HPClock.h>
+#include <functional>
 
 #include <experimental/filesystem>
 namespace filesystem = std::experimental::filesystem;


### PR DESCRIPTION
Got a few errors when compiling, e.g.:

```
In file included from /home/dimrok/projects/pumex/src/pumex/AssetBufferNode.cpp:23:0:
/home/dimrok/projects/pumex/include/pumex/AssetBufferNode.h:62:95: error: ‘std::function’ has not been declared
   inline void                                                      setEventResizeOutputs(std::function<void(uint32_t, size_t)> event);
```

Adding the two missing `#include <functional>` fixed it.