### PR TITLE
Use the default copy constructor and default assignment operator.

### DIFF
--- a/include/pumex/Image.h
+++ b/include/pumex/Image.h
@@ -36,8 +36,8 @@ struct PUMEX_EXPORT ImageTraits
   explicit ImageTraits(VkImageUsageFlags usage, VkFormat format, const VkExtent3D& extent, uint32_t mipLevels = 1, uint32_t arrayLayers = 1, VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT,
     bool linearTiling = false, VkImageLayout initialLayout = VK_IMAGE_LAYOUT_UNDEFINED, VkImageCreateFlags imageCreate = 0,
     VkImageType imageType = VK_IMAGE_TYPE_2D, VkSharingMode sharingMode = VK_SHARING_MODE_EXCLUSIVE);
-  ImageTraits(const ImageTraits& traits);
-  ImageTraits& operator=(const ImageTraits& traits);
+  ImageTraits(const ImageTraits& traits) = default;
+  ImageTraits& operator=(const ImageTraits& traits) = default;
 
   VkImageUsageFlags        usage          = VK_IMAGE_USAGE_SAMPLED_BIT;
   VkFormat                 format         = VK_FORMAT_B8G8R8A8_UNORM;

--- a/include/pumex/MemoryObjectBarrier.h
+++ b/include/pumex/MemoryObjectBarrier.h
@@ -39,8 +39,8 @@ public:
   MemoryObjectBarrier();
   MemoryObjectBarrier(VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask, uint32_t srcQueueFamilyIndex, uint32_t dstQueueFamilyIndex, std::shared_ptr<MemoryObject> memoryObject, VkImageLayout oldLayout, VkImageLayout newLayout, const ImageSubresourceRange& imageRange);
   MemoryObjectBarrier(VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask, uint32_t srcQueueFamilyIndex, uint32_t dstQueueFamilyIndex, std::shared_ptr<MemoryObject> memoryObject, const BufferSubresourceRange& bufferRange);
-  MemoryObjectBarrier(const MemoryObjectBarrier&);
-  MemoryObjectBarrier& operator=(const MemoryObjectBarrier&);
+  MemoryObjectBarrier(const MemoryObjectBarrier&) = default;
+  MemoryObjectBarrier& operator=(const MemoryObjectBarrier&) = default;
   ~MemoryObjectBarrier();
 
   MemoryObject::Type            objectType;

--- a/include/pumex/RenderPass.h
+++ b/include/pumex/RenderPass.h
@@ -75,7 +75,7 @@ struct PUMEX_EXPORT SubpassDefinition
 {
   SubpassDefinition();
   SubpassDefinition(VkPipelineBindPoint pipelineBindPoint, const std::vector<AttachmentReference>& inputAttachments, const std::vector<AttachmentReference>& colorAttachments, const std::vector<AttachmentReference>& resolveAttachments, const AttachmentReference& depthStencilAttachment, const std::vector<uint32_t>& preserveAttachments, VkSubpassDescriptionFlags flags = 0x0, uint32_t multiViewMask = 0x0);
-  SubpassDefinition& operator=(const SubpassDefinition& subpassDefinition);
+  SubpassDefinition& operator=(const SubpassDefinition& subpassDefinition) = default;
 
   VkPipelineBindPoint                pipelineBindPoint;
   std::vector<VkAttachmentReference> inputAttachments;

--- a/src/pumex/Image.cpp
+++ b/src/pumex/Image.cpp
@@ -32,31 +32,6 @@ ImageTraits::ImageTraits(VkImageUsageFlags u, VkFormat f, const VkExtent3D& e, u
 {
 }
 
-ImageTraits::ImageTraits(const ImageTraits& traits)
-  : usage{ traits.usage }, format{ traits.format }, extent(traits.extent), mipLevels{ traits.mipLevels }, arrayLayers{ traits.arrayLayers }, samples{ traits.samples },
-  linearTiling{ traits.linearTiling }, initialLayout{ traits.initialLayout }, imageCreate{ traits.imageCreate }, imageType{ traits.imageType }, sharingMode{ traits.sharingMode }
-{
-}
-
-ImageTraits& ImageTraits::operator=(const ImageTraits& traits)
-{
-  if (this != &traits)
-  {
-    usage = traits.usage;
-    format = traits.format;
-    extent = traits.extent;
-    mipLevels = traits.mipLevels;
-    arrayLayers = traits.arrayLayers;
-    samples = traits.samples;
-    linearTiling = traits.linearTiling;
-    initialLayout = traits.initialLayout;
-    imageCreate = traits.imageCreate;
-    imageType = traits.imageType;
-    sharingMode = traits.sharingMode;
-  }
-  return *this;
-}
-
 Image::Image(Device* d, const ImageTraits& it, std::shared_ptr<DeviceMemoryAllocator> a)
   : imageTraits{ it }, device(d->device), allocator{ a }, ownsImage{ true }
 {

--- a/src/pumex/MemoryObjectBarrier.cpp
+++ b/src/pumex/MemoryObjectBarrier.cpp
@@ -39,30 +39,6 @@ MemoryObjectBarrier::MemoryObjectBarrier(VkAccessFlags sam, VkAccessFlags dam, u
 {
 }
 
-MemoryObjectBarrier::MemoryObjectBarrier(const MemoryObjectBarrier& rhs)
-  : objectType(rhs.objectType), srcAccessMask{ rhs.srcAccessMask }, dstAccessMask{ rhs.dstAccessMask }, srcQueueFamilyIndex{ rhs.srcQueueFamilyIndex }, dstQueueFamilyIndex{ rhs.dstQueueFamilyIndex }, memoryObject{ rhs.memoryObject },
-    oldLayout{ rhs.oldLayout }, newLayout{ rhs.newLayout }, imageRange{ rhs.imageRange }, bufferRange{ rhs.bufferRange }
-{
-}
-
-MemoryObjectBarrier& MemoryObjectBarrier::operator=(const MemoryObjectBarrier& rhs)
-{
-  if (this != &rhs)
-  {
-    objectType            = rhs.objectType;
-    srcAccessMask         = rhs.srcAccessMask;
-    dstAccessMask         = rhs.dstAccessMask;
-    srcQueueFamilyIndex   = rhs.srcQueueFamilyIndex;
-    dstQueueFamilyIndex   = rhs.dstQueueFamilyIndex;
-    memoryObject          = rhs.memoryObject;
-    oldLayout             = rhs.oldLayout;
-    newLayout             = rhs.newLayout;
-    imageRange            = rhs.imageRange;
-    bufferRange           = rhs.bufferRange;
-  }
-  return *this;
-}
-
 MemoryObjectBarrier::~MemoryObjectBarrier()
 {
 }

--- a/src/pumex/RenderPass.cpp
+++ b/src/pumex/RenderPass.cpp
@@ -88,22 +88,6 @@ SubpassDefinition::SubpassDefinition(VkPipelineBindPoint pbp, const std::vector<
   depthStencilAttachment = da.getReference();
 }
 
-SubpassDefinition& SubpassDefinition::operator=(const SubpassDefinition& subpassDefinition)
-{
-  if (this != &subpassDefinition)
-  {
-    pipelineBindPoint      = subpassDefinition.pipelineBindPoint;
-    inputAttachments       = subpassDefinition.inputAttachments;
-    colorAttachments       = subpassDefinition.colorAttachments;
-    resolveAttachments     = subpassDefinition.resolveAttachments;
-    depthStencilAttachment = subpassDefinition.depthStencilAttachment;
-    preserveAttachments    = subpassDefinition.preserveAttachments;
-    flags                  = subpassDefinition.flags;
-    multiViewMask          = subpassDefinition.multiViewMask;
-  }
-  return *this;
-}
-
 // Be advised : resulting description is as long valid as SubpassDefinition exists.
 // We are passing pointers to internal elements here
 VkSubpassDescription SubpassDefinition::getDescription() const


### PR DESCRIPTION
Use the default copy constructor and assignment operator instead of implementing them.

In the three cases found, no fancy operations were done, just plain copy.